### PR TITLE
Update miLazyCracker.sh

### DIFF
--- a/miLazyCracker.sh
+++ b/miLazyCracker.sh
@@ -116,7 +116,7 @@ rm -f "$TMPFILE_UNK" "$TMPFILE_FND" "0x${myUID}_"*".txt"
 if [ $mfocResult -eq 0 ]; then
     echo -e "\n\nDump left in: $TMPFILE_MFD"
     if ask "Do you want clone the card? Place card on reader now and press Y"; then
-         nfc-mfclassic W a $TMPFILE_MFD
+         nfc-mfclassic w A u $TMPFILE_MFD
     fi
 else
     rm -f "$TMPFILE_MFD"


### PR DESCRIPTION
Now it works as expected.

Before this, it turns out the `nfc-mfclassic` menu

~~~
Do you want clone the card? Place card on reader now and press Y [y/n] Y
Usage: nfc-mfclassic f|r|R|w|W a|b u|U<01ab23cd> <dump.mfd> [<keys.mfd> [f]]
  f|r|R|w|W     - Perform format (f) or read from (r) or unlocked read from (R) or write to (w) or unlocked write to (W) card
                  *** format will reset all keys to FFFFFFFFFFFF and all data to 00 and all ACLs to default
                  *** unlocked read does not require authentication and will reveal A and B keys
                  *** note that unlocked write will attempt to overwrite block 0 including UID
                  *** unlocking only works with special Mifare 1K cards (Chinese clones)
  a|A|b|B       - Use A or B keys for action; Halt on errors (a|b) or tolerate errors (A|B)
  u|U           - Use any (u) uid or supply a uid specifically as U01ab23cd.
  <dump.mfd>    - MiFare Dump (MFD) used to write (card to MFD) or (MFD to card)
  <keys.mfd>    - MiFare Dump (MFD) that contain the keys (optional)
  f             - Force using the keyfile even if UID does not match (optional)
Examples: 

  Read card to file, using key A:

    nfc-mfclassic r a u mycard.mfd

  Write file to blank card, using key A:

    nfc-mfclassic w a u mycard.mfd

  Write new data and/or keys to previously written card, using key A:

    nfc-mfclassic w a u newdata.mfd mycard.mfd

  Format/wipe card (note two passes required to ensure writes for all ACL cases):

    nfc-mfclassic f A u dummy.mfd keyfile.mfd f
    nfc-mfclassic f B u dummy.mfd keyfile.mfd f

  Read card to file, using key A and uid 0x01 0xab 0x23 0xcd:

    nfc-mfclassic r a U01ab23cd mycard.mfd
~~~
